### PR TITLE
Remove radio-browser module

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "got": "^11.8.1",
     "lyrics-finder": "^21.7.0",
     "nekos.life": "^2.0.7",
-    "radio-browser": "^2.1.6",
     "utf-8-validate": "^5.0.4",
     "weather-js": "^2.0.0"
   },


### PR DESCRIPTION
The same version of the radio-browser module is repeated twice in the premises, not being necessary.